### PR TITLE
Change date view in profiler

### DIFF
--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -46,7 +46,7 @@ final class MongoQuerySerializer
         }
 
         if (method_exists($item, 'toDateTime')) {
-            return $item->toDateTime()->format('r');
+            return 'ISODate("' . $item->toDateTime()->format('c') . '")';
         }
 
         if (method_exists($item, '__toString')) {

--- a/src/Resources/views/Collector/mongo.html.twig
+++ b/src/Resources/views/Collector/mongo.html.twig
@@ -253,7 +253,7 @@
 
         var facileMongoDbBundlePrettify = function (query)
         {
-            query = query.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            query = query.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"ISODate\(\\"(.*)\\"\)"/g,  'ISODate("$1")');
             return query.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
                 var cssClass = 'number';
                 if (/^"/.test(match)) {


### PR DESCRIPTION
In order to make the query runnable in any MongoDB shell without any modification, i changed the way the Date fields are printed in the profiler, showing the format accepted (which is `ISODate("Y-m-dTH:i:s.v")`).