### PR TITLE
Fix query serializer

### DIFF
--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main" >>
 RUN export DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-   && apt-get install -y \
+    && apt-get install -y \
         libbz2-dev \
         libcurl4-openssl-dev \
         libedit-dev \
@@ -50,7 +50,8 @@ RUN apt-get update \
 RUN pecl install mongodb-1.3.0 \
     && docker-php-ext-enable mongodb
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer global require hirak/prestissimo
 
 ENV TEST_ENV=docker
 

--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -32,11 +32,12 @@ final class MongoQuerySerializer
             $data = $data->bsonSerialize();
         }
 
+        $newData = [];
         foreach ($data as $key => $item) {
-            $data[$key] = self::prepareItemData($item);
+            $newData[$key] = self::prepareItemData($item);
         }
 
-        return $data;
+        return $newData;
     }
 
     /**


### PR DESCRIPTION
Using a normal BSONDocument with a `replaceOne`, for some strange reason the `$data = $data->bsonSerialize();` call of the `MongoQuerySerializer::prepareUnserializableData` returns a `stdClass`, so the subsequent calls fails.

This should fix it; I've also added hirak/prestissimo inside the dev container.