### PR TITLE
Add an other edge case to be handled by the query serializer

### DIFF
--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -47,6 +47,10 @@ final class MongoQuerySerializer
      */
     public static function prepareItemData($item)
     {
+        if (\is_string($item)) {
+            return $item;
+        }
+
         if (method_exists($item, 'getArrayCopy')) {
             return self::prepareUnserializableData($item->getArrayCopy());
         }
@@ -63,11 +67,10 @@ final class MongoQuerySerializer
             return $item->bsonSerialize();
         }
 
-        if (is_array($item) || is_object($item)) {
+        if (\is_array($item) || \is_object($item)) {
             return self::prepareUnserializableData((array) $item);
         }
 
         return $item;
     }
-
 }

--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -67,7 +67,7 @@ final class MongoQuerySerializer
             return $item->bsonSerialize();
         }
 
-        if (\is_array($item) || \is_object($item)) {
+        if (is_array($item) || is_object($item)) {
             return self::prepareUnserializableData((array) $item);
         }
 

--- a/tests/Unit/DataCollector/MongoQuerySerializerTest.php
+++ b/tests/Unit/DataCollector/MongoQuerySerializerTest.php
@@ -39,10 +39,15 @@ class MongoQuerySerializerTest extends TestCase
         $dateTime = $date->toDateTime();
         $isoDate = sprintf('ISODate("%sT%s+00:00")', $dateTime->format('Y-m-d'), $dateTime->format('H:i:s'));
 
+        // regression: string which is a FQCN of a class that has __toString
+        $documentWithFQCN = new BSONDocument();
+        $documentWithFQCN->fqcn = \Exception::class;
+
         return [
             [['test' => $date], $isoDate],
             [['test' => new BSONDocument()], []],
             [['test' => new \stdClass()], []],
+            [['test' => $documentWithFQCN], ['fqcn' => \Exception::class]],
         ];
     }
 


### PR DESCRIPTION
As in title... If the to-be-serialized data is a string which is the FQCN of a class that has the `__toString()` method, the behavior of this line makes the serializer go on fatal error:

https://github.com/facile-it/mongodb-bundle/blob/39f35bf8d0f5cefb4a70b7a6bd385b5773218e60/src/DataCollector/MongoQuerySerializer.php#L62-L64