### PR TITLE
Use Makefile instead of bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,4 @@
 /.styleci.yml       export-ignore
 /phpunit.xml.dist   export-ignore
 /docker-compose.yml export-ignore
-/setup.sh           export-ignore
-/start.sh           export-ignore
-/test.sh            export-ignore
+/Makefile           export-ignore

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: up setup start test
 
-up:
+up: docker-compose.yml
 	docker-compose up -d --force-recreate
 
-setup:
+setup: docker-compose.yml composer.json
 	docker-compose run --rm php-cli composer install
 
 start: up
 	docker exec -ti mb_php bash
 
-test:
+test: docker-compose.yml phpunit.xml.dist
 	docker-compose run --rm php-cli bash -c "sleep 3 && bin/phpunit -c phpunit.xml.dist"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: up setup start test
+
+up:
+	docker-compose up -d --force-recreate
+
+setup:
+	docker-compose run --rm php-cli composer install
+
+start: up
+	docker exec -ti mb_php bash
+
+test:
+	docker-compose run --rm php-cli bash -c "sleep 3 && bin/phpunit -c phpunit.xml.dist"

--- a/README.MD
+++ b/README.MD
@@ -122,14 +122,14 @@ If you like docker, this repository is provided with a dev environment with some
 All you need is docker and docker-compose installed on your system.
 
 ```
- ./setup.sh  # will build the needed containers and setup the project
+ make setup  # will build the needed containers and setup the project
 ```
 
 ```
- ./start.sh  # will start the needed containers and put you inside the php-cli container
+ make start  # will start the needed containers and put you inside the php-cli container
 ```
 
 ```
- ./test.sh  # will launch the test suite
+ make test  # will launch the test suite
 ```
 Note: All these scripts are meant to be used outside the containers.

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose up -d --force-recreate
-docker exec -ti mb_php composer install
-docker-compose stop

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose up -d --force-recreate
-docker exec -ti mb_php bash

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose start
-docker exec -ti mb_php bin/phpunit -c phpunit.xml.dist


### PR DESCRIPTION
Use Makefile instead of bash scripts for preventing file missing errors and centralizing commands.
