### PR TITLE
Register commands manually to avoid SF 3.4 deprecation

### DIFF
--- a/src/DependencyInjection/MongoDbBundleExtension.php
+++ b/src/DependencyInjection/MongoDbBundleExtension.php
@@ -2,6 +2,9 @@
 
 namespace Facile\MongoDbBundle\DependencyInjection;
 
+use Facile\MongoDbBundle\Command\DropCollectionCommand;
+use Facile\MongoDbBundle\Command\DropDatabaseCommand;
+use Facile\MongoDbBundle\Command\LoadFixturesCommand;
 use Facile\MongoDbBundle\DataCollector\MongoDbDataCollector;
 use Facile\MongoDbBundle\Event\ConnectionEvent;
 use Facile\MongoDbBundle\Event\Listener\DataCollectorListener;
@@ -42,6 +45,7 @@ final class MongoDbBundleExtension extends Extension
         $this->defineClientRegistry($config['clients'], $container->getParameter("kernel.environment"));
         $this->defineConnectionFactory();
         $this->defineConnections($config['connections']);
+        $this->defineCommands();
 
         if ($this->mustCollectData($config)) {
             $this->defineLoggers();
@@ -198,5 +202,19 @@ final class MongoDbBundleExtension extends Extension
         $explainServiceDefinition->setPublic(true);
 
         $this->containerBuilder->setDefinition('mongo.explain_query_service', $explainServiceDefinition);
+    }
+
+    private function defineCommands()
+    {
+        $commandClasses = [
+            DropCollectionCommand::class,
+            DropDatabaseCommand::class,
+            LoadFixturesCommand::class,
+        ];
+
+        foreach ($commandClasses as $command) {
+            $this->containerBuilder->setDefinition($command, new Definition($command))
+                ->addTag('console.command');
+        }
     }
 }

--- a/tests/Functional/DependencyInjection/MongoDbBundleExtensionTest.php
+++ b/tests/Functional/DependencyInjection/MongoDbBundleExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facile\MongoDbBundle\Tests\functional\DependencyInjection;
+namespace Facile\MongoDbBundle\Tests\Functional\DependencyInjection;
 
 use Facile\MongoDbBundle\Capsule\Database as LoggerDatabase;
 use Facile\MongoDbBundle\DependencyInjection\MongoDbBundleExtension;


### PR DESCRIPTION
Under Symfony 4, commands are no longer auto-registered due to `\Command` path and `Command` suffix. This registers the commands manually to avoid this issue (and deprecations under Symfony 3.4).