### PR TITLE
Fix Profiler errors on symfony4+

### DIFF
--- a/src/Resources/config/profiler.xml
+++ b/src/Resources/config/profiler.xml
@@ -25,7 +25,7 @@
                 <argument type="service" id="facile_mongo_db.logger"/>
             </call>
             <tag name="data_collector" id="mongodb" priority="250"
-                 template="FacileMongoDbBundle:Collector:mongo.html.twig"/>
+                 template="@FacileMongoDb:Collector:mongo.html.twig"/>
         </service>
 
         <service id="mongo.explain_query_service"

--- a/src/Resources/config/profiler.xml
+++ b/src/Resources/config/profiler.xml
@@ -25,7 +25,7 @@
                 <argument type="service" id="facile_mongo_db.logger"/>
             </call>
             <tag name="data_collector" id="mongodb" priority="250"
-                 template="@FacileMongoDb:Collector:mongo.html.twig"/>
+                 template="@FacileMongoDb/Collector/mongo.html.twig"/>
         </service>
 
         <service id="mongo.explain_query_service"


### PR DESCRIPTION
This change fixes the inability to load the profiler bar on symfony 4. (potentially 3.4 as well). Current behavior prior to this change shows a profiler bar error stating the bar couldn't load and the data collector template can't be found.