### PR TITLE
Add ability to specify order of loading fixtures

### DIFF
--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -116,7 +116,7 @@ class LoadFixturesCommand extends AbstractCommand
 
     /**
      * Sorts fixtures by getOrder in case of implementing OrderedFixtureInterface
-     * Prioritizes fixtures with interface
+     * Fixtures with interface will be after the rest
      *
      * @param array $fixtures
      * @return self
@@ -135,7 +135,8 @@ class LoadFixturesCommand extends AbstractCommand
                 return 1;
             }
 
-            return ($isFixture1Instance) ? -1 : 1;
+
+            return ($isFixture2Instance) ? -1 : 1;
 
 
         });

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -4,6 +4,8 @@ namespace Facile\MongoDbBundle\Command;
 
 use Facile\MongoDbBundle\Fixtures\MongoFixturesLoader;
 use Facile\MongoDbBundle\Fixtures\MongoFixtureInterface;
+use Facile\MongoDbBundle\Fixtures\OrderedFixtureInterface;
+
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,6 +59,8 @@ class LoadFixturesCommand extends AbstractCommand
             );
         }
 
+        $this->sortFixtures($fixtures);
+
         foreach ($fixtures as $fixture) {
             $this->loadFixture($fixture);
         }
@@ -109,4 +113,36 @@ class LoadFixturesCommand extends AbstractCommand
             }
         }
     }
+
+    /**
+     * Sorts fixtures by getOrder in case of implementing OrderedFixtureInterface
+     * Prioritizes fixtures with interface
+     *
+     * @param array $fixtures
+     * @return self
+     */
+    protected function sortFixtures(&$fixtures): self
+    {
+        usort($fixtures, function ($fixture1, $fixture2) {
+            $isFixture1Instance = ($fixture1 instanceof OrderedFixtureInterface);
+            $isFixture2Instance = ($fixture2 instanceof OrderedFixtureInterface);
+
+            if ($isFixture1Instance && $isFixture2Instance) {
+                return $fixture1->getOrder() - $fixture2->getOrder();
+            }
+
+            if (!$isFixture1Instance && !$isFixture2Instance) {
+                return 1;
+            }
+
+            return ($isFixture1Instance) ? -1 : 1;
+
+
+        });
+
+        return $this;
+
+    }
+
+
 }

--- a/src/Fixtures/OrderedFixtureInterface.php
+++ b/src/Fixtures/OrderedFixtureInterface.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Facile\MongoDbBundle\Fixtures;
+
+
+/**
+ * Ordered Fixture interface needs to be implemented by fixtures,
+ * which needs to have a specific order
+ *
+ * The fixtures without this interfance will be loaded after those with it
+ *
+ * @author Marcin Moskal <moskalmarcin@yahoo.com>
+ */
+interface OrderedFixtureInterface
+{
+    /**
+     * Get the order of this fixture
+     *
+     * @return integer
+     */
+    public function getOrder();
+
+}

--- a/tests/Functional/Command/LoadFixturesCommandTest.php
+++ b/tests/Functional/Command/LoadFixturesCommandTest.php
@@ -97,9 +97,15 @@ class LoadFixturesAppTest extends AppTestCase
         $fixtures = $collection->find(['type' => 'fixture']);
         $fixtures = $fixtures->toArray();
 
+        self::assertEquals(3, count($fixtures));
+
         $fixture = current($fixtures);
 
-        self::assertEquals(3, count($fixtures));
+        self::assertEquals('fixture', $fixture['type']);
+        self::assertEquals('Batman Begins - 2005', $fixture['data']);
+        self::assertEquals(0, $fixture['expectedPosition']);
+
+        $fixture = next($fixtures);
 
         self::assertEquals('fixture', $fixture['type']);
         self::assertEquals('Edward Scissorhands - 1990', $fixture['data']);

--- a/tests/fixtures/DataFixtures/TestOrderedMongoFixtures.php
+++ b/tests/fixtures/DataFixtures/TestOrderedMongoFixtures.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Facile\MongoDbBundle\Tests\fixtures\DataFixtures;
+
+use Facile\MongoDbBundle\Capsule\Database;
+use Facile\MongoDbBundle\Fixtures\AbstractContainerAwareFixture;
+use Facile\MongoDbBundle\Fixtures\MongoFixtureInterface;
+use Facile\MongoDbBundle\Fixtures\OrderedFixtureInterface;
+
+class TestOrderedMongoFixtures extends AbstractContainerAwareFixture implements MongoFixtureInterface, OrderedFixtureInterface
+{
+    /**
+     * @return array
+     */
+    public function loadData()
+    {
+        $doc = [
+            'type' => 'fixture',
+            'data' => 'Edward Scissorhands - 1990',
+            'expectedPosition' => 1
+        ];
+
+        /** @var Database $connection */
+        $connection = $this->getContainer()->get('mongo.connection.test_db');
+        $collection = $connection->selectCollection($this->collection());
+        $collection->insertOne($doc);
+    }
+
+    /**
+     * Gets priority to sort fixtures order
+     */
+    public function getOrder()
+    {
+        return 1;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function loadIndexes()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function collection(): string
+    {
+        return 'testFixturesOrderedCollection';
+    }
+}

--- a/tests/fixtures/DataFixtures/TestOrderedMongoFixtures1.php
+++ b/tests/fixtures/DataFixtures/TestOrderedMongoFixtures1.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Facile\MongoDbBundle\tests\fixtures\DataFixtures;
+
+use Facile\MongoDbBundle\Capsule\Database;
+use Facile\MongoDbBundle\Fixtures\AbstractContainerAwareFixture;
+use Facile\MongoDbBundle\Fixtures\MongoFixtureInterface;
+use Facile\MongoDbBundle\Fixtures\OrderedFixtureInterface;
+
+class TestOrderedMongoFixtures1 extends AbstractContainerAwareFixture implements MongoFixtureInterface, OrderedFixtureInterface
+{
+    /**
+     * @return array
+     */
+    public function loadData()
+    {
+        $doc = [
+            'type' => 'fixture',
+            'data' => 'Alice in Wonderland - 2010',
+            'expectedPosition' => 2
+        ];
+
+        /** @var Database $connection */
+        $connection = $this->getContainer()->get('mongo.connection.test_db');
+        $collection = $connection->selectCollection($this->collection());
+        $collection->insertOne($doc);
+    }
+
+    /**
+     * Gets priority to sort fixtures order
+     */
+    public function getOrder()
+    {
+        return 200;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function loadIndexes()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function collection(): string
+    {
+        return 'testFixturesOrderedCollection';
+    }
+}

--- a/tests/fixtures/DataFixtures/TestOrderedMongoFixtures2.php
+++ b/tests/fixtures/DataFixtures/TestOrderedMongoFixtures2.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Facile\MongoDbBundle\Tests\fixtures\DataFixtures;
+
+use Facile\MongoDbBundle\Capsule\Database;
+use Facile\MongoDbBundle\Fixtures\AbstractContainerAwareFixture;
+use Facile\MongoDbBundle\Fixtures\MongoFixtureInterface;
+use Facile\MongoDbBundle\Fixtures\OrderedFixtureInterface;
+
+class TestOrderedMongoFixtures2 extends AbstractContainerAwareFixture implements MongoFixtureInterface
+{
+    /**
+     * @return array
+     */
+    public function loadData()
+    {
+        $doc = [
+            'type' => 'fixture',
+            'data' => 'Batman Begins - 2005',
+        ];
+
+
+        /** @var Database $connection */
+        $connection = $this->getContainer()->get('mongo.connection.test_db');
+        $collection = $connection->selectCollection($this->collection());
+        $collection->insertOne($doc);
+    }
+
+    /**
+     * @return array
+     */
+    public function loadIndexes()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function collection(): string
+    {
+        return 'testFixturesOrderedCollection';
+    }
+}

--- a/tests/fixtures/DataFixtures/TestOrderedMongoFixtures2.php
+++ b/tests/fixtures/DataFixtures/TestOrderedMongoFixtures2.php
@@ -19,6 +19,7 @@ class TestOrderedMongoFixtures2 extends AbstractContainerAwareFixture implements
         $doc = [
             'type' => 'fixture',
             'data' => 'Batman Begins - 2005',
+            'expectedPosition' => 0,
         ];
 
 


### PR DESCRIPTION
Might be useful in case of loading depending fixtures like groups and users

Fixture should implement `Facile\MongoDbBundle\Fixtures\OrderedFixtureInterface` with `getOrder` method

For reference: https://github.com/facile-it/mongodb-bundle/pull/53