### PR TITLE
Fix MongoFixtureInterface signature

### DIFF
--- a/src/Fixtures/MongoFixtureInterface.php
+++ b/src/Fixtures/MongoFixtureInterface.php
@@ -8,17 +8,17 @@ namespace Facile\MongoDbBundle\Fixtures;
 interface MongoFixtureInterface
 {
     /**
-     * @return array
+     * @return void
      */
     public function loadData();
 
     /**
-     * @return array
+     * @return void
      */
     public function loadIndexes();
 
     /**
-     * @return string
+     * @return void
      */
     public function collection(): string;
 }


### PR DESCRIPTION
I'm having issues with PHPStan due to this PHPDocs; this methods do not return anything, so I cannot declare those as `: void`.

A more brutal approach could be taken (but breaking BC) appending `: void` to the methods.