### PR TITLE
CI updates minimum stability on-the-fly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ install:
   - |
     if [ "$SYMFONY" != "" ]; then
       if [[ "$SYMFONY" = "dev-master" ]]; then
-        docker-compose run --no-deps --rm php-cli composer config minimum-stability stable
+        docker-compose run --no-deps --rm php-cli composer config minimum-stability dev
       fi;
       docker-compose run --no-deps --rm php-cli composer require "symfony/symfony:${SYMFONY}" --no-update;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ install:
   - |
     if [ "$SYMFONY" != "" ]; then
       if [[ "$SYMFONY" = "dev-master" ]]; then
-        sed 's/minimum-stability\": \"stable/minimum-stability\": \"dev/' -i composer.json
+        docker-compose run --no-deps --rm php-cli composer config minimum-stability stable
       fi;
       docker-compose run --no-deps --rm php-cli composer require "symfony/symfony:${SYMFONY}" --no-update;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,10 @@ install:
   - sudo chmod -R 777 . # ugly! Travis is 2000:2000
   - |
     if [ "$SYMFONY" != "" ]; then
-    docker-compose run --no-deps --rm php-cli composer require "symfony/symfony:${SYMFONY}" --no-update;
+      if [[ "$SYMFONY" = "dev-master" ]]; then
+        sed 's/minimum-stability\": \"stable/minimum-stability\": \"dev/' -i composer.json
+      fi;
+      docker-compose run --no-deps --rm php-cli composer require "symfony/symfony:${SYMFONY}" --no-update;
     fi;
   - docker-compose run --no-deps --rm php-cli composer install --prefer-dist --no-interaction ${COMPOSER_FLAGS}
 


### PR DESCRIPTION
In CI composer.json minimum stability is changed to `dev` when symfony dev-master is required