### PR TITLE
Fix event dispatcher deprecations in SF 4.3

### DIFF
--- a/src/Services/ClientRegistry.php
+++ b/src/Services/ClientRegistry.php
@@ -7,6 +7,7 @@ use Facile\MongoDbBundle\Event\ConnectionEvent;
 use Facile\MongoDbBundle\Models\ClientConfiguration;
 use MongoDB\Client;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Class ClientRegistry.
@@ -37,6 +38,10 @@ final class ClientRegistry
      */
     public function __construct(EventDispatcherInterface $eventDispatcher, string $environment)
     {
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
+        }
+
         $this->clients = [];
         $this->configurations = [];
         $this->environment = $environment;
@@ -146,8 +151,8 @@ final class ClientRegistry
             $this->clients[$clientKey] = $this->buildClient($name, $conf->getUri(), $options, []);
 
             $this->eventDispatcher->dispatch(
-                ConnectionEvent::CLIENT_CREATED,
-                new ConnectionEvent($clientKey)
+                new ConnectionEvent($clientKey),
+                ConnectionEvent::CLIENT_CREATED
             );
         }
 

--- a/tests/Functional/Capsule/CollectionTest.php
+++ b/tests/Functional/Capsule/CollectionTest.php
@@ -186,7 +186,7 @@ class CollectionTest extends AppTestCase
      */
     protected function assertEventsDispatching($ev)
     {
-        $ev->dispatch(QueryEvent::QUERY_PREPARED, Argument::type(QueryEvent::class))->shouldBeCalled();
-        $ev->dispatch(QueryEvent::QUERY_EXECUTED, Argument::type(QueryEvent::class))->shouldBeCalled();
+        $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_PREPARED)->shouldBeCalled();
+        $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_EXECUTED)->shouldBeCalled();
     }
 }

--- a/tests/Functional/Capsule/CollectionTest.php
+++ b/tests/Functional/Capsule/CollectionTest.php
@@ -6,6 +6,7 @@ use Facile\MongoDbBundle\Tests\Functional\AppTestCase;
 use MongoDB\Driver\Manager;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class CollectionTest extends AppTestCase
 {
@@ -186,7 +187,12 @@ class CollectionTest extends AppTestCase
      */
     protected function assertEventsDispatching($ev)
     {
-        $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_PREPARED)->shouldBeCalled();
-        $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_EXECUTED)->shouldBeCalled();
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_PREPARED)->shouldBeCalled();
+            $ev->dispatch(Argument::type(QueryEvent::class), QueryEvent::QUERY_EXECUTED)->shouldBeCalled();
+        } else {
+            $ev->dispatch(QueryEvent::QUERY_PREPARED, Argument::type(QueryEvent::class))->shouldBeCalled();
+            $ev->dispatch(QueryEvent::QUERY_EXECUTED, Argument::type(QueryEvent::class))->shouldBeCalled();
+        }
     }
 }


### PR DESCRIPTION
Symfony 4.3 changed the way the dispatcher behaves to follow suit with PSR-14: https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching

This PR fixes the new deprecation warnings: https://travis-ci.org/facile-it/mongodb-bundle/builds/544663503