### PR TITLE
Removing fallback logic about authSource

### DIFF
--- a/src/Services/ClientRegistry.php
+++ b/src/Services/ClientRegistry.php
@@ -114,10 +114,8 @@ final class ClientRegistry
         if (! isset($this->clients[$clientKey])) {
             $conf = $this->configurations[$name];
             $options = array_merge(
-                [
-                    'database' => $databaseName,
-                    'authSource' => $conf->getAuthSource() ?? $databaseName ?? 'admin',
-                ],
+                ['database' => $databaseName],
+                $conf->getAuthSource() !== null ? ['authSource' => $conf->getAuthSource()] : [],
                 $conf->getOptions()
             );
             $this->clients[$clientKey] = $this->buildClient($name, $conf->getUri(), $options, $conf->getDriverOptions());


### PR DESCRIPTION
#96 complains about some fallback logic about authSource filling. 

This PR aims to make authSource config straightforward and predictable removing the fallback logic introduced in previous version of this bundle.