### PR TITLE
Allow PHP8 and fix issue with MongoQuerySerializer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,12 @@ jobs:
           - php: 7.4
             mongo-ext: 1.9.0
             mongo-img: percona/percona-server-mongodb:4.4
+          - php: 8.0
+            mongo-ext: 1.6.0
+            mongo-img: percona/percona-server-mongodb:4.2
+          - php: 8.0
+            mongo-ext: 1.9.0
+            mongo-img: percona/percona-server-mongodb:4.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
           - php: 8.0
             mongo-ext: 1.9.0
             mongo-img: percona/percona-server-mongodb:4.4
+            symfony: '5.0.*'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,6 @@ jobs:
           - php: 8.0
             mongo-ext: 1.9.0
             mongo-img: percona/percona-server-mongodb:4.4
-            symfony: '5.0.*'
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,9 +64,6 @@ jobs:
             mongo-ext: 1.9.0
             mongo-img: percona/percona-server-mongodb:4.4
           - php: 8.0
-            mongo-ext: 1.6.0
-            mongo-img: percona/percona-server-mongodb:4.2
-          - php: 8.0
             mongo-ext: 1.9.0
             mongo-img: percona/percona-server-mongodb:4.4
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3 || ^4",
         "symfony/web-profiler-bundle": "^3.4 || ^4.3",
         "symfony/console": "^3.4 || ^4.3",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "symfony/phpunit-bridge": "^4.2",
         "facile-it/facile-coding-standard": "^0.4.1",
         "phpstan/phpstan": "^0.12"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console": "^3.4 || ^4.3",
         "phpunit/phpunit": "^7.0",
         "symfony/phpunit-bridge": "^4.2",
-        "facile-it/facile-coding-standard": "^0.4.0 || dev-master",
+        "facile-it/facile-coding-standard": "^0.4.1",
         "phpstan/phpstan": "^0.12"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-mongodb": "^1.1.5",
         "mongodb/mongodb": "^1.0",
         "symfony/framework-bundle": "^3.4 || ^4.3"

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         "symfony/framework-bundle": "^3.4 || ^4.3"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^3",
+        "matthiasnoback/symfony-dependency-injection-test": "^3 || ^4",
         "symfony/web-profiler-bundle": "^3.4 || ^4.3",
         "symfony/console": "^3.4 || ^4.3",
         "phpunit/phpunit": "^7.0",
         "symfony/phpunit-bridge": "^4.2",
-        "facile-it/facile-coding-standard": "^0.4.0",
+        "facile-it/facile-coding-standard": "^0.4.0 || dev-master",
         "phpstan/phpstan": "^0.12"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3 || ^4",
         "symfony/web-profiler-bundle": "^3.4 || ^4.3",
         "symfony/console": "^3.4 || ^4.3",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "symfony/phpunit-bridge": "^4.2",
         "facile-it/facile-coding-standard": "^0.4.1",
         "phpstan/phpstan": "^0.12"

--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -50,8 +50,12 @@ final class MongoQuerySerializer
      */
     public static function prepareItemData($item)
     {
-        if (\is_string($item)) {
+        if (\is_scalar($item)) {
             return $item;
+        }
+
+        if (\is_array($item)) {
+            return self::prepareUnserializableData((array) $item);
         }
 
         if (method_exists($item, 'getArrayCopy')) {
@@ -70,7 +74,7 @@ final class MongoQuerySerializer
             return $item->bsonSerialize();
         }
 
-        if (\is_array($item) || \is_object($item)) {
+        if (\is_object($item)) {
             return self::prepareUnserializableData((array) $item);
         }
 

--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -50,7 +50,7 @@ final class MongoQuerySerializer
      */
     public static function prepareItemData($item)
     {
-        if (\is_scalar($item)) {
+        if (\is_scalar($item) || \is_null($item)) {
             return $item;
         }
 

--- a/tests/Functional/Command/AbstractCommandTest.php
+++ b/tests/Functional/Command/AbstractCommandTest.php
@@ -24,7 +24,7 @@ class AbstractCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array_merge(['command' => $command->getName()], $arguments));
 
-        self::assertContains('Executed', $commandTester->getDisplay());
+        self::assertStringContainsString('Executed', $commandTester->getDisplay());
     }
 
     public function test_AbstractCommand_connection_exception()

--- a/tests/Functional/Command/DropCollectionCommandTest.php
+++ b/tests/Functional/Command/DropCollectionCommandTest.php
@@ -27,7 +27,7 @@ class DropCollectionCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), 'collection' => 'testFunctionalCollection']);
 
-        self::assertContains('Collection dropped', $commandTester->getDisplay());
+        self::assertStringContainsString('Collection dropped', $commandTester->getDisplay());
     }
 
     private function addCommandToApplication()

--- a/tests/Functional/Command/DropDatabaseCommandTest.php
+++ b/tests/Functional/Command/DropDatabaseCommandTest.php
@@ -26,7 +26,7 @@ class DropDatabaseCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        self::assertContains('Database dropped', $commandTester->getDisplay());
+        self::assertStringContainsString('Database dropped', $commandTester->getDisplay());
     }
 
     private function addCommandToApplication()

--- a/tests/Functional/Command/LoadFixturesCommandTest.php
+++ b/tests/Functional/Command/LoadFixturesCommandTest.php
@@ -52,7 +52,7 @@ class LoadFixturesCommandTest extends AppTestCase
         self::assertEquals('fixture', $fixtures[0]['type']);
         self::assertEquals('test', $fixtures[0]['data']);
 
-        self::assertContains('Done, loaded 4 fixtures files', $commandTester->getDisplay());
+        self::assertStringContainsString('Done, loaded 4 fixtures files', $commandTester->getDisplay());
     }
 
     public function test_command_not_fixtures_found()

--- a/tests/Functional/Command/LoadFixturesCommandTest.php
+++ b/tests/Functional/Command/LoadFixturesCommandTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class LoadFixturesCommandTest extends AppTestCase
 {
-    /** @var Database $conn */
+    /** @var Database */
     private $conn;
 
     protected function setUp(): void

--- a/tests/Unit/DataCollector/MongoQuerySerializerTest.php
+++ b/tests/Unit/DataCollector/MongoQuerySerializerTest.php
@@ -24,12 +24,8 @@ class MongoQuerySerializerTest extends TestCase
         $query->setData($unserializedData);
         $query->setOptions($unserializedData);
 
-        $clone = clone $query;
         MongoQuerySerializer::serialize($query);
 
-        $this->assertNotEquals($clone->getFilters(), $query->getFilters());
-        $this->assertNotEquals($clone->getData(), $query->getData());
-        $this->assertNotEquals($clone->getOptions(), $query->getOptions());
         $this->assertEquals($expectedSerialization, $query->getFilters()['test']);
         $this->assertEquals($expectedSerialization, $query->getData()['test']);
         $this->assertEquals($expectedSerialization, $query->getOptions()['test']);
@@ -50,6 +46,8 @@ class MongoQuerySerializerTest extends TestCase
             [['test' => new BSONDocument()], []],
             [['test' => new \stdClass()], []],
             [['test' => $documentWithFQCN], ['fqcn' => \Exception::class]],
+            [['test' => 'stringValue'], 'stringValue'],
+            [['test' => 145], 145],
         ];
     }
 

--- a/tests/Unit/Fixtures/FixtureSorterTest.php
+++ b/tests/Unit/Fixtures/FixtureSorterTest.php
@@ -29,11 +29,11 @@ class FixtureSorterTest extends TestCase
             )
         );
 
-        $this->assertContains('a', $collectionsSorted);
-        $this->assertContains('b', $collectionsSorted);
-        $this->assertContains('c', $collectionsSorted);
-        $this->assertContains('d', $collectionsSorted);
-        $this->assertContains('e', $collectionsSorted);
+        $this->assertStringContainsString('a', $collectionsSorted);
+        $this->assertStringContainsString('b', $collectionsSorted);
+        $this->assertStringContainsString('c', $collectionsSorted);
+        $this->assertStringContainsString('d', $collectionsSorted);
+        $this->assertStringContainsString('e', $collectionsSorted);
 
         $this->assertIsAfter($collectionsSorted, 'a', ['b', 'c', 'd', 'e']);
         $this->assertIsAfter($collectionsSorted, 'b', ['c', 'e']);


### PR DESCRIPTION
Not sure if you are planning to support PHP8, but that would be great!

I tried it and got some errors with MongoQuerySerializer:
`method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given`

Did not encounter any other issues, but I also do not use all features. Would it be possible to run the travis build on PHP8 too?
