### PR TITLE
Fix issue with MongoQuerySerializer

### DIFF
--- a/src/DataCollector/MongoQuerySerializer.php
+++ b/src/DataCollector/MongoQuerySerializer.php
@@ -50,8 +50,12 @@ final class MongoQuerySerializer
      */
     public static function prepareItemData($item)
     {
-        if (\is_string($item)) {
+        if (\is_scalar($item)) {
             return $item;
+        }
+
+        if (\is_array($item)) {
+            return self::prepareUnserializableData((array) $item);
         }
 
         if (method_exists($item, 'getArrayCopy')) {
@@ -70,7 +74,7 @@ final class MongoQuerySerializer
             return $item->bsonSerialize();
         }
 
-        if (\is_array($item) || \is_object($item)) {
+        if (\is_object($item)) {
             return self::prepareUnserializableData((array) $item);
         }
 

--- a/tests/Unit/DataCollector/MongoQuerySerializerTest.php
+++ b/tests/Unit/DataCollector/MongoQuerySerializerTest.php
@@ -24,12 +24,8 @@ class MongoQuerySerializerTest extends TestCase
         $query->setData($unserializedData);
         $query->setOptions($unserializedData);
 
-        $clone = clone $query;
         MongoQuerySerializer::serialize($query);
 
-        $this->assertNotEquals($clone->getFilters(), $query->getFilters());
-        $this->assertNotEquals($clone->getData(), $query->getData());
-        $this->assertNotEquals($clone->getOptions(), $query->getOptions());
         $this->assertEquals($expectedSerialization, $query->getFilters()['test']);
         $this->assertEquals($expectedSerialization, $query->getData()['test']);
         $this->assertEquals($expectedSerialization, $query->getOptions()['test']);
@@ -50,6 +46,8 @@ class MongoQuerySerializerTest extends TestCase
             [['test' => new BSONDocument()], []],
             [['test' => new \stdClass()], []],
             [['test' => $documentWithFQCN], ['fqcn' => \Exception::class]],
+            [['test' => 'stringValue'], 'stringValue'],
+            [['test' => 145], 145],
         ];
     }
 


### PR DESCRIPTION
Split of #104 

This PR prepares the code to be forward compatible with PHP8, but without the actual PHP8 upgrade.