### PR TITLE
Update to PHPUnit 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3",
         "symfony/web-profiler-bundle": "^3.4 || ^4.3",
         "symfony/console": "^3.4 || ^4.3",
-        "phpunit/phpunit": "^7.0",
-        "symfony/phpunit-bridge": "^4.2",
+        "phpunit/phpunit": "^8.0",
+        "symfony/phpunit-bridge": "^5.2",
         "facile-it/facile-coding-standard": "^0.4.0",
         "phpstan/phpstan": "^0.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^3",
+        "matthiasnoback/symfony-dependency-injection-test": "^4",
         "symfony/web-profiler-bundle": "^3.4 || ^4.3",
         "symfony/console": "^3.4 || ^4.3",
         "phpunit/phpunit": "^8.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -416,8 +416,13 @@ parameters:
 			path: src/DataCollector/MongoQuerySerializer.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\TreeBuilder\\:\\:root\\(\\)\\.$#"
+			count: 1
+			path: src/DependencyInjection/Configuration.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
-			count: 7
+			count: 3
 			path: src/DependencyInjection/Configuration.php
 
 		-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.0/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/tests/Functional/Command/AbstractCommandTest.php
+++ b/tests/Functional/Command/AbstractCommandTest.php
@@ -24,7 +24,7 @@ class AbstractCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array_merge(['command' => $command->getName()], $arguments));
 
-        self::assertContains('Executed', $commandTester->getDisplay());
+        self::assertStringContainsString('Executed', $commandTester->getDisplay());
     }
 
     public function test_AbstractCommand_connection_exception()

--- a/tests/Functional/Command/DropCollectionCommandTest.php
+++ b/tests/Functional/Command/DropCollectionCommandTest.php
@@ -27,7 +27,7 @@ class DropCollectionCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName(), 'collection' => 'testFunctionalCollection']);
 
-        self::assertContains('Collection dropped', $commandTester->getDisplay());
+        self::assertStringContainsString('Collection dropped', $commandTester->getDisplay());
     }
 
     private function addCommandToApplication()

--- a/tests/Functional/Command/DropDatabaseCommandTest.php
+++ b/tests/Functional/Command/DropDatabaseCommandTest.php
@@ -26,7 +26,7 @@ class DropDatabaseCommandTest extends AppTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(['command' => $command->getName()]);
 
-        self::assertContains('Database dropped', $commandTester->getDisplay());
+        self::assertStringContainsString('Database dropped', $commandTester->getDisplay());
     }
 
     private function addCommandToApplication()

--- a/tests/Functional/Command/LoadFixturesCommandTest.php
+++ b/tests/Functional/Command/LoadFixturesCommandTest.php
@@ -52,7 +52,7 @@ class LoadFixturesCommandTest extends AppTestCase
         self::assertEquals('fixture', $fixtures[0]['type']);
         self::assertEquals('test', $fixtures[0]['data']);
 
-        self::assertContains('Done, loaded 4 fixtures files', $commandTester->getDisplay());
+        self::assertStringContainsString('Done, loaded 4 fixtures files', $commandTester->getDisplay());
     }
 
     public function test_command_not_fixtures_found()

--- a/tests/Unit/Fixtures/FixtureSorterTest.php
+++ b/tests/Unit/Fixtures/FixtureSorterTest.php
@@ -29,11 +29,11 @@ class FixtureSorterTest extends TestCase
             )
         );
 
-        $this->assertContains('a', $collectionsSorted);
-        $this->assertContains('b', $collectionsSorted);
-        $this->assertContains('c', $collectionsSorted);
-        $this->assertContains('d', $collectionsSorted);
-        $this->assertContains('e', $collectionsSorted);
+        $this->assertStringContainsString('a', $collectionsSorted);
+        $this->assertStringContainsString('b', $collectionsSorted);
+        $this->assertStringContainsString('c', $collectionsSorted);
+        $this->assertStringContainsString('d', $collectionsSorted);
+        $this->assertStringContainsString('e', $collectionsSorted);
 
         $this->assertIsAfter($collectionsSorted, 'a', ['b', 'c', 'd', 'e']);
         $this->assertIsAfter($collectionsSorted, 'b', ['c', 'e']);


### PR DESCRIPTION
#104 and #111 made evident that we cannot properly test Symfony 5 without PHPUnit 8.
This PR is a split from #104 to just update that.

I'm gonna ignore deprecations for now and handle them in #111.