### PR TITLE
Symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         "php": "^7.2 || ^8.0",
         "ext-mongodb": "^1.1.5",
         "mongodb/mongodb": "^1.0",
-        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0"
+        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4",
-        "symfony/web-profiler-bundle": "^3.4 || ^4.3 || ^5.0",
-        "symfony/console": "^3.4 || ^4.3 || ^5.0",
+        "symfony/web-profiler-bundle": "^3.4 || ^4.3 || ^5.0 || ^6.0",
+        "symfony/console": "^3.4 || ^4.3 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^8.5.14",
-        "symfony/phpunit-bridge": "^5.2",
+        "symfony/phpunit-bridge": "^6.0",
         "facile-it/facile-coding-standard": "^0.4.0",
         "phpstan/phpstan": "^0.12.88",
         "phpstan/extension-installer": "^1.1",
@@ -56,7 +56,11 @@
         }
     },
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "allow-plugins": {
+            "facile-it/facile-coding-standard": true,
+            "phpstan/extension-installer": true
+        }
     },
     "scripts": {
         "cs-check": "php-cs-fixer fix --dry-run --diff --config=.php-cs.php",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -461,17 +461,7 @@ parameters:
 			path: src/Event/Listener/DataCollectorListener.php
 
 		-
-			message: "#^Method Facile\\\\MongoDbBundle\\\\Event\\\\Listener\\\\DataCollectorListener\\:\\:onConnectionClientCreated\\(\\) has parameter \\$event with no value type specified in iterable type Facile\\\\MongoDbBundle\\\\Event\\\\ConnectionEvent\\.$#"
-			count: 1
-			path: src/Event/Listener/DataCollectorListener.php
-
-		-
 			message: "#^Method Facile\\\\MongoDbBundle\\\\Event\\\\Listener\\\\DataCollectorListener\\:\\:onQueryExecuted\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/Event/Listener/DataCollectorListener.php
-
-		-
-			message: "#^Method Facile\\\\MongoDbBundle\\\\Event\\\\Listener\\\\DataCollectorListener\\:\\:onQueryExecuted\\(\\) has parameter \\$event with no value type specified in iterable type Facile\\\\MongoDbBundle\\\\Event\\\\QueryEvent\\.$#"
 			count: 1
 			path: src/Event/Listener/DataCollectorListener.php
 
@@ -517,11 +507,6 @@ parameters:
 
 		-
 			message: "#^Method Facile\\\\MongoDbBundle\\\\Fixtures\\\\MongoFixturesLoader\\:\\:loadFromIterator\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Fixtures/MongoFixturesLoader.php
-
-		-
-			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
 			count: 1
 			path: src/Fixtures/MongoFixturesLoader.php
 

--- a/src/FacileMongoDbBundle.php
+++ b/src/FacileMongoDbBundle.php
@@ -5,17 +5,12 @@ declare(strict_types=1);
 namespace Facile\MongoDbBundle;
 
 use Facile\MongoDbBundle\DependencyInjection\MongoDbBundleExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Class FacileMongoDbBundle.
- */
 final class FacileMongoDbBundle extends Bundle
 {
-    /**
-     * @return MongoDbBundleExtension
-     */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new MongoDbBundleExtension();
     }

--- a/src/Fixtures/MongoFixturesLoader.php
+++ b/src/Fixtures/MongoFixturesLoader.php
@@ -60,6 +60,7 @@ final class MongoFixturesLoader
         return array_reduce(
             $declared,
             function ($classList, string $className) use ($includedFiles) {
+                /** @var class-string $className */
                 $reflClass = new \ReflectionClass($className);
                 $sourceFile = $reflClass->getFileName();
 

--- a/tests/Functional/TestApp/TestKernel.php
+++ b/tests/Functional/TestApp/TestKernel.php
@@ -7,17 +7,17 @@ namespace Facile\MongoDbBundle\Tests\Functional\TestApp;
 use Facile\MongoDbBundle\FacileMongoDbBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-/**
- * Class TestKernel.
- */
 class TestKernel extends Kernel
 {
     /**
      * {@inheritdoc}
+     *
+     * @return Bundle[]
      */
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),


### PR DESCRIPTION
This is mostly to remove deprecations when using 5.4, but at the same time it opens the road for 6.0.