### PR TITLE
Add maximum depth to serializer to prevent infinite recursion (#167)

### DIFF
--- a/tests/Unit/DataCollector/MongoQuerySerializerTest.php
+++ b/tests/Unit/DataCollector/MongoQuerySerializerTest.php
@@ -52,6 +52,29 @@ class MongoQuerySerializerTest extends TestCase
         ];
     }
 
+    public function test_serializer_terminating(): void
+    {
+        // tests that the serializer terminates when serializing an object which references itself
+        $selfReferencingObject = new class {
+            public $self;
+
+            public function __construct(
+            ) {
+                $this->self = $this;
+            }
+        };
+        $data = ['test' => $selfReferencingObject];
+
+        $query = new Query();
+        $query->setFilters($data);
+        $query->setData($data);
+        $query->setOptions($data);
+
+        MongoQuerySerializer::serialize($query);
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function test_serializer_regression_with_replaceOne(): void
     {
         $stdClass = new \stdClass();


### PR DESCRIPTION
Fixes #167 

I'm not sure if this is a good approach. Other suggestions are welcome.

Thanks for reacting to the issue @ilario-pierbattista and thanks for creating this great library.

The issue doesn't really have a high priority, as one shouldn't put circular objects into a Mongo database anyway. So if you don't want to merge this or don't want to fix the issue I can totally understand.

