### PR TITLE
Fix deprecated warning using mongodb extension 1.20 or greater in ReadPrederence::getMode()

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,10 @@ jobs:
             mongo-ext: 1.6.0
             mongo-img: 4.2
             symfony: "^4.4"
+          - php: 7.4
+            mongo-ext: 1.20.0
+            mongo-img: 5.0
+            symfony: "^4.4"
           - php: 8.1
             mongo-ext: 1.12.0
             mongo-img: 5.0

--- a/src/Capsule/Collection.php
+++ b/src/Capsule/Collection.php
@@ -206,6 +206,10 @@ final class Collection extends MongoCollection
 
     private function translateReadPreference(ReadPreference $readPreference): string
     {
+        if (version_compare(phpversion('mongodb'), '1.20.0', '>=')) {
+            return $readPreference->getModeString();
+        }
+
         switch ($readPreference->getMode()) {
             case ReadPreference::RP_PRIMARY:
                 return 'primary';

--- a/src/Capsule/Collection.php
+++ b/src/Capsule/Collection.php
@@ -206,7 +206,7 @@ final class Collection extends MongoCollection
 
     private function translateReadPreference(ReadPreference $readPreference): string
     {
-        if (version_compare(phpversion('mongodb'), '1.20.0', '>=')) {
+        if (method_exists(ReadPreference::class, 'getModeString')) {
             return $readPreference->getModeString();
         }
 

--- a/tests/Unit/Capsule/DatabaseTest.php
+++ b/tests/Unit/Capsule/DatabaseTest.php
@@ -33,8 +33,12 @@ class DatabaseTest extends TestCase
         self::assertEquals('testdb', $debugInfo['databaseName']);
     }
 
-    public function test_withOptions(): void
+    public function test_withOptions_using_mongodb_extension_lower_than_1_20_0(): void
     {
+        if (version_compare(phpversion('mongodb'), '1.20.0', '>=')) {
+            $this->markTestSkipped('This test requires mongodb extension version 1.20.0 or later.');
+        }
+
         $manager = new Manager('mongodb://localhost');
         $logger = $this->prophesize(EventDispatcherInterface::class);
 
@@ -49,5 +53,30 @@ class DatabaseTest extends TestCase
         self::assertSame($manager, $debugInfo['manager']);
         self::assertEquals('testdb', $debugInfo['databaseName']);
         self::assertEquals(ReadPreference::RP_NEAREST, $debugInfo['readPreference']->getMode());
+    }
+
+    /**
+     * @requires extension mongodb 1.20.0
+     */
+    public function test_withOptions_using_mongodb_extension_1_20_0_or_greater(): void
+    {
+        if (version_compare(phpversion('mongodb'), '1.20.0', '<')) {
+            $this->markTestSkipped('This test requires mongodb extension version 1.20.0 or later.');
+        }
+
+        $manager = new Manager('mongodb://localhost');
+        $logger = $this->prophesize(EventDispatcherInterface::class);
+
+        $db = new Database($manager, 'client_name', 'testdb', [], $logger->reveal());
+        self::assertInstanceOf(\MongoDB\Database::class, $db);
+
+        $newDb = $db->withOptions(['readPreference' => new ReadPreference(ReadPreference::NEAREST)]);
+
+        self::assertInstanceOf(Database::class, $newDb);
+
+        $debugInfo = $newDb->__debugInfo();
+        self::assertSame($manager, $debugInfo['manager']);
+        self::assertEquals('testdb', $debugInfo['databaseName']);
+        self::assertEquals(ReadPreference::NEAREST, $debugInfo['readPreference']->getModeString());
     }
 }

--- a/tests/Unit/Capsule/DatabaseTest.php
+++ b/tests/Unit/Capsule/DatabaseTest.php
@@ -33,7 +33,7 @@ class DatabaseTest extends TestCase
         self::assertEquals('testdb', $debugInfo['databaseName']);
     }
 
-    public function test_withOptions_using_mongodb_extension_lower_than_1_20_0(): void
+    public function test_withOptions(): void
     {
         $manager = new Manager('mongodb://localhost');
         $logger = $this->prophesize(EventDispatcherInterface::class);


### PR DESCRIPTION
Steps to reproduce:
1. Add the following option to makefile
```
.PHONY: setup-74-mongo-5
setup-74-mongo-5: PHP_VERSION=7.4
setup-74-mongo-5: MONGODB_EXTENSION_VERSION=1.20.0
setup-74-mongo-5: MONGODB_VERSION=5.0
setup-74-mongo-5: | --build --setup-common
```
2. Enter to the container: `make sh`
3. Execute unit tests: `make tests`

Added a mongodb version check in order to use _getModeString()_ method instead of calling _getMode()_
Added tests to check

PS: I don't like so much the way I tested it. If you have any suggestion, please feel free to comment it. Thanks!

Resolves #185 https://github.com/facile-it/mongodb-bundle/issues/185