### PR TITLE
Add profiling for countDocuments() and estimatedDocumentCount()

### DIFF
--- a/src/Capsule/Collection.php
+++ b/src/Capsule/Collection.php
@@ -63,6 +63,18 @@ final class Collection extends MongoCollection
     /**
      * @inheritDoc
      */
+    public function countDocuments($filter = [], array $options = [])
+    {
+        $query = $this->prepareQuery(__FUNCTION__, $filter, [], $options);
+        $result = parent::countDocuments($query->getFilters(), $query->getOptions());
+        $this->notifyQueryExecution($query);
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function find($filter = [], array $options = [])
     {
         $query = $this->prepareQuery(__FUNCTION__, $filter, [], $options);
@@ -175,6 +187,18 @@ final class Collection extends MongoCollection
     {
         $query = $this->prepareQuery(__FUNCTION__, $filter, ['fieldName' => $fieldName], $options);
         $result = parent::distinct($fieldName, $query->getFilters(), $query->getOptions());
+        $this->notifyQueryExecution($query);
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function estimatedDocumentCount(array $options = [])
+    {
+        $query = $this->prepareQuery(__FUNCTION__, [], [], $options);
+        $result = parent::estimatedDocumentCount($options);
         $this->notifyQueryExecution($query);
 
         return $result;

--- a/tests/Functional/Capsule/CollectionTest.php
+++ b/tests/Functional/Capsule/CollectionTest.php
@@ -71,6 +71,17 @@ class CollectionTest extends AppTestCase
         $coll->count(['test' => 1]);
     }
 
+    public function test_countDocuments(): void
+    {
+        $manager = $this->getManager();
+        $ev = $this->prophesize(EventDispatcherInterface::class);
+        $this->assertEventsDispatching($ev);
+
+        $coll = new Collection($manager, 'test_client', 'testdb', 'test_collection', [], $ev->reveal());
+
+        $coll->countDocuments(['test' => 1]);
+    }
+
     public function test_find(): void
     {
         $manager = $this->getManager();
@@ -188,6 +199,17 @@ class CollectionTest extends AppTestCase
         $coll = new Collection($manager, 'test_client', 'testdb', 'test_collection', [], $ev->reveal());
 
         $coll->distinct('field');
+    }
+
+    public function test_estimatedDocumentCount(): void
+    {
+        $manager = $this->getManager();
+        $ev = $this->prophesize(EventDispatcherInterface::class);
+        $this->assertEventsDispatching($ev);
+
+        $coll = new Collection($manager, 'test_client', 'testdb', 'test_document', [], $ev->reveal());
+
+        $coll->estimatedDocumentCount();
     }
 
     protected function assertEventsDispatching($ev)


### PR DESCRIPTION
The profiling was already set for `count()`, but this method is deprecated since 1.4 and has been replaced by `countDocuments()`.

As GromNaN mentioned [here](https://github.com/facile-it/mongodb-bundle/issues/10), we could get rid of encapsulation by using MongoDB built-in monitoring features, but it would require to refactor a large part of the bundle, so I went for the simple solution.